### PR TITLE
Add ESP32 touchscreen MicroPython port

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,37 @@ sudo systemctl start nginx
 
 You can purchase the GAN cube used for this project here: [GAN Smart Cube](https://amzn.to/4lgux9D).
 
+## ESP32 Touchscreen Port
+
+An initial MicroPython port targeting the **ESP32-2432S022C** board
+with built‑in 2.2" capacitive touchscreen is available under the
+[`esp32/`](esp32/) directory.  The port drives a MAX98357A I2S audio
+amplifier for alarm playback and uses the ST7789 display controller. A
+simple UI shows the current time, two editable alarms, and cube
+connection/scramble status.
+
+### Quick start
+
+1. Flash [MicroPython](https://micropython.org/download/ESP32_GENERIC/)
+   onto the board.
+2. Copy `esp32/*.py` and `sounds/alarm.wav` to the device's filesystem.
+3. Wire a MAX98357A module to the default I2S pins:
+
+   | Signal | ESP32 Pin |
+   | ------ | --------- |
+   | `BCLK` | GPIO14    |
+   | `LRC`  | GPIO15    |
+   | `DIN`  | GPIO32    |
+
+4. Reset the board – the home screen shows the current time, two alarm
+   slots, and cube status. Tap the top area to set the time or the bottom
+   corners to configure alarms. The alarm sound plays when a scheduled
+   time is reached and stops on touch.
+
+The MicroPython port is a work in progress; BLE integration with the
+GAN cube and a full alarm scheduler are still to be implemented so cube
+status is currently a placeholder.
+
 ## API Endpoints
 
 The backend exposes a small set of HTTP routes for managing alarms and cube state.

--- a/esp32/__init__.py
+++ b/esp32/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: LicenseRef-CubeAlarm-Custom-Attribution
+# Copyright (c) 2025 Paul Shapiro
+"""MicroPython helpers for the ESP32 touchscreen port."""

--- a/esp32/audio.py
+++ b/esp32/audio.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: LicenseRef-CubeAlarm-Custom-Attribution
+# Copyright (c) 2025 Paul Shapiro
+"""ESP32 Audio Manager using MAX98357A I2S amplifier.
+
+This module provides a lightweight audio playback helper intended for
+MicroPython running on the ESP32-2432S022C board.  It streams 16-bit
+mono WAV files over I2S to a connected MAX98357A DAC.
+
+The pin assignments match the default wiring on the board but can be
+customised when instantiating :class:`ESP32AudioManager`.
+"""
+
+from machine import I2S, Pin
+import uasyncio as asyncio
+
+class ESP32AudioManager:
+    """Simple audio playback helper for I2S DACs."""
+
+    def __init__(self, sck: Pin = Pin(14), ws: Pin = Pin(15), sd: Pin = Pin(32)):
+        # Configure I2S for transmitting 16-bit mono samples at 44.1kHz
+        self.i2s = I2S(
+            0,
+            sck=sck,
+            ws=ws,
+            sd=sd,
+            mode=I2S.TX,
+            bits=16,
+            format=I2S.MONO,
+            rate=44_100,
+            ibuf=20_000,
+        )
+        self._task = None
+
+    def _play_wav(self, path: str) -> None:
+        """Stream a WAV file to the DAC once."""
+        with open(path, "rb") as wav:
+            # Skip WAV header (44 bytes) – assumes PCM little-endian
+            wav.seek(44)
+            while True:
+                data = wav.read(1024)
+                if not data:
+                    break
+                self.i2s.write(data)
+
+    async def _loop(self, path: str) -> None:
+        """Continuously play ``path`` until cancelled."""
+        try:
+            while True:
+                self._play_wav(path)
+                await asyncio.sleep(0)
+        finally:
+            # Ensure the DAC is quiet when the task is cancelled
+            silence = b"\x00\x00" * 256
+            self.i2s.write(silence)
+
+    def start_alarm(self, path: str = "alarm.wav") -> None:
+        """Start looping the given WAV file."""
+        if self._task is None:
+            loop = asyncio.get_event_loop()
+            self._task = loop.create_task(self._loop(path))
+
+    def stop_alarm(self) -> None:
+        """Stop audio playback."""
+        if self._task:
+            self._task.cancel()
+            self._task = None
+
+    def deinit(self) -> None:
+        """Release the I2S peripheral."""
+        self.stop_alarm()
+        self.i2s.deinit()

--- a/esp32/display.py
+++ b/esp32/display.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: LicenseRef-CubeAlarm-Custom-Attribution
+# Copyright (c) 2025 Paul Shapiro
+"""Display and touch helpers for the ESP32-2432S022C board.
+
+The board integrates a 2.2" 240x320 ST7789 TFT driven over SPI and a
+capacitive touch controller.  This module provides minimal wrappers
+around commonly used MicroPython drivers for drawing text and reading
+touch coordinates.
+"""
+
+from machine import Pin, SPI, I2C
+import st7789
+
+try:
+    import ft6x36  # driver for FT6x36/FT6336 capacitive touch IC
+except ImportError:  # pragma: no cover - optional dependency
+    ft6x36 = None
+
+
+class TouchDisplay:
+    """Helper class combining TFT screen and touch controller."""
+
+    def __init__(self, rotation: int = 1):
+        # SPI configuration for the ST7789 display
+        spi = SPI(
+            2,
+            baudrate=60_000_000,
+            sck=Pin(18),
+            mosi=Pin(23),
+            miso=Pin(19),
+        )
+        self.tft = st7789.ST7789(
+            spi,
+            240,
+            320,
+            reset=Pin(12, Pin.OUT),
+            cs=Pin(5, Pin.OUT),
+            dc=Pin(16, Pin.OUT),
+            backlight=Pin(4, Pin.OUT),
+            rotation=rotation,
+        )
+        self.tft.init()
+
+        # Optional capacitive touch controller over I2C
+        self._touch = None
+        if ft6x36 is not None:
+            i2c = I2C(0, sda=Pin(21), scl=Pin(22))
+            self._touch = ft6x36.FT6x36(i2c)
+
+    def fill(self, color: int) -> None:
+        self.tft.fill(color)
+
+    def text(self, msg: str, x: int = 0, y: int = 0, color: int = st7789.WHITE) -> None:
+        self.tft.text(msg, x, y, color)
+
+    def get_touch(self):
+        """Return the current touch coordinates or ``None`` if untouched."""
+        if self._touch and self._touch.touched:
+            return self._touch.get_point()
+        return None
+
+    # ------------------------------------------------------------------
+    # High level helpers used by ``main.py``
+
+    def show_home(self, now, alarms, connected: bool, scrambled: bool) -> None:
+        """Render the home screen with time, alarms and cube status."""
+        self.fill(st7789.BLACK)
+
+        hour, minute = now[4], now[5]
+        self.text(f"Time {hour:02d}:{minute:02d}", 10, 10)
+
+        for idx, alarm in enumerate(alarms):
+            if alarm:
+                ah, am = alarm
+                msg = f"A{idx+1} {ah:02d}:{am:02d}"
+            else:
+                msg = f"A{idx+1} --:--"
+            self.text(msg, 10, 30 + idx * 20)
+
+        status = "Connected" if connected else "No Cube"
+        cube_state = "Scrambled" if scrambled else "Solved"
+        self.text(f"Cube: {status}", 10, 80)
+        self.text(cube_state, 10, 100)
+        self.text("Tap time or alarm to edit", 10, 140)
+
+    def show_set_screen(self, label: str, hour: int, minute: int) -> None:
+        """Display a simple time adjustment screen."""
+        self.fill(st7789.BLACK)
+        self.text(f"Set {label}", 10, 10)
+        self.text(f"{hour:02d}:{minute:02d}", 80, 120)
+        self.text("L:+hour R:+min", 10, 200)
+        self.text("Bottom=save", 10, 220)

--- a/esp32/main.py
+++ b/esp32/main.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: LicenseRef-CubeAlarm-Custom-Attribution
+# Copyright (c) 2025 Paul Shapiro
+"""MicroPython alarm clock for the ESP32-2432S022C board.
+
+This script demonstrates using the integrated touchscreen to display and
+configure a simple clock with two alarms.  It also reports the connection
+and scramble state of the cube.  When an alarm fires it plays a WAV file
+through a MAX98357A I2S amplifier until the screen is touched.
+"""
+
+import uasyncio as asyncio
+import machine
+from display import TouchDisplay
+from audio import ESP32AudioManager
+
+ALARM_WAV = "alarm.wav"
+
+
+class ClockApp:
+    """Minimal touchscreen alarm clock."""
+
+    def __init__(self) -> None:
+        self.display = TouchDisplay()
+        self.audio = ESP32AudioManager()
+        self.rtc = machine.RTC()
+        self.alarms = [None, None]  # each alarm is (hour, minute) or None
+        self.cube_connected = False
+        self.cube_scrambled = True
+        self._last_alarm_minute = None
+
+    # ------------------------------------------------------------------
+    # Touch helpers
+
+    async def set_time(self) -> None:
+        dt = list(self.rtc.datetime())
+        hour, minute = dt[4], dt[5]
+        while True:
+            self.display.show_set_screen("Time", hour, minute)
+            touch = self.display.get_touch()
+            if touch:
+                x, y = touch
+                if y > 260:  # bottom area saves
+                    dt[4], dt[5] = hour, minute
+                    self.rtc.datetime(tuple(dt))
+                    return
+                elif x < 120:
+                    hour = (hour + 1) % 24
+                else:
+                    minute = (minute + 1) % 60
+            await asyncio.sleep(0.2)
+
+    async def set_alarm(self, idx: int) -> None:
+        hour, minute = self.alarms[idx] or (0, 0)
+        while True:
+            self.display.show_set_screen(f"Alarm {idx + 1}", hour, minute)
+            touch = self.display.get_touch()
+            if touch:
+                x, y = touch
+                if y > 260:
+                    self.alarms[idx] = (hour, minute)
+                    return
+                elif x < 120:
+                    hour = (hour + 1) % 24
+                else:
+                    minute = (minute + 1) % 60
+            await asyncio.sleep(0.2)
+
+    async def alarm_task(self) -> None:
+        self.display.fill(0)
+        self.display.text("Solve cube to stop!", 10, 150)
+        self.audio.start_alarm(ALARM_WAV)
+        try:
+            while True:
+                if self.display.get_touch():
+                    break
+                await asyncio.sleep(0.1)
+        finally:
+            self.audio.stop_alarm()
+
+    # ------------------------------------------------------------------
+
+    async def run(self) -> None:
+        while True:
+            now = self.rtc.datetime()
+            self.display.show_home(
+                now, self.alarms, self.cube_connected, self.cube_scrambled
+            )
+
+            touch = self.display.get_touch()
+            if touch:
+                x, y = touch
+                if y < 80:
+                    await self.set_time()
+                elif x < 120:
+                    await self.set_alarm(0)
+                else:
+                    await self.set_alarm(1)
+
+            # Check alarms once per loop
+            for alarm in self.alarms:
+                if not alarm:
+                    continue
+                ah, am = alarm
+                if (
+                    now[4] == ah
+                    and now[5] == am
+                    and self._last_alarm_minute != now[5]
+                ):
+                    await self.alarm_task()
+                    self._last_alarm_minute = now[5]
+
+            await asyncio.sleep(1)
+
+    def deinit(self) -> None:
+        self.audio.deinit()
+
+
+async def _main() -> None:
+    app = ClockApp()
+    try:
+        await app.run()
+    finally:
+        app.deinit()
+
+
+asyncio.run(_main())
+


### PR DESCRIPTION
## Summary
- introduce `esp32` MicroPython implementation for ESP32-2432S022C touchscreen board
- provide I2S audio manager for MAX98357A and ST7789 display/touch helpers
- document setup and wiring for the new board in README
- add touchscreen UI for setting time, managing two alarms, and showing cube status

## Testing
- `python -m py_compile esp32/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6894f0f9ae588325a2e1533ce3e66a03