### PR TITLE
Add clock and alarm scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
+# Cube Alarm ESP32
+
+MicroPython firmware that turns a GAN Bluetooth cube into an alarm clock.
+
+## Clock and alarm
+
+- **Button A** (GP14) – hold to enter/exit time‑setting mode. While in this mode
+  press **A** to increment hours and **B** to increment minutes.
+- **Button B** (GP15) – hold to enter/exit alarm‑setting mode. While in alarm
+  mode press **A** to increment hours and **B** to increment minutes.
+- The cube is only polled shortly before the alarm (about 10 seconds) to avoid
+  draining its battery.
+- Stop the alarm by solving the cube or long‑pressing **B**.
+
+## REPL helpers
+
+For quick testing you can schedule alarms from the REPL after running
+`main.run()`:
+
+```python
+import main
+main.set_alarm(7, 30)      # set an alarm at 07:30
+main.set_alarm_in(30)      # alarm 30 seconds from now
+```
 


### PR DESCRIPTION
## Summary
- add RTC-backed time and alarm configuration via buttons
- start cube polling only shortly before alarm triggers
- expose helper functions to schedule test alarms from REPL

## Testing
- `python -m py_compile pico/main.py`
- `python -m py_compile pico/audio_alarm.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5cdf96bf48325ab076ba8431c49a6