### PR TITLE
Expand clock display and handle framebuf dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ MicroPython firmware that turns a GAN Bluetooth cube into an alarm clock.
 - The cube is only polled shortly before the alarm (about 10 seconds) to avoid
   draining its battery.
 - Stop the alarm by solving the cube or long‑pressing **B**.
+- The OLED display shows the current time in a large 12‑hour format.
 
 ## REPL helpers
 


### PR DESCRIPTION
## Summary
- Render scaled text on OLED, falling back when `framebuf` isn't available
- Show the time in 12‑hour format with AM/PM and fill the entire screen
- Document 12‑hour clock display in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cryptolib')*

------
https://chatgpt.com/codex/tasks/task_e_68b5e31307488325817a25659859be22